### PR TITLE
Add block timestamp to global blocks

### DIFF
--- a/bullseyeapp/templates/bullseye/data_components/blocks.html
+++ b/bullseyeapp/templates/bullseye/data_components/blocks.html
@@ -18,7 +18,7 @@
           <div id="collapseBlocksGlobal" class="accordion-collapse collapse" aria-labelledby="headingBlocksGlobal">
             <div class="accordion-body">
               {% for entry in globalblocks %}
-	      <p>{{ entry.address }} <a href="https://meta.wikimedia.org/wiki/Special:Log?type=gblblock&page={{ entry.address | urlencode}}">blocked</a> ({{entry.reason}}) by {{ entry.by }} until {{ entry.expiry }}</p>
+	      <p>{{ entry.address }} <a href="https://meta.wikimedia.org/wiki/Special:Log?type=gblblock&page={{ entry.address | urlencode}}">blocked</a> ({{entry.reason}}) on {{ entry.timestamp }} by {{ entry.by }} until {{ entry.expiry }}</p>
               {% endfor %}
             </div>
           </div>


### PR DESCRIPTION
Adding a timestamp to global blocks, so that we don't have to check the log to see when it was blocked.